### PR TITLE
clean up examples

### DIFF
--- a/azure/HandsOnTutorial/10-using-cloud-dictionary.fsx
+++ b/azure/HandsOnTutorial/10-using-cloud-dictionary.fsx
@@ -25,19 +25,21 @@ let dict =
     } |> cluster.Run
 
 // add an entry to the dictionary
-cluster.StoreClient.Dictionary.Add "key0" 42 dict
-cluster.StoreClient.Dictionary.ContainsKey "key0" dict
-cluster.StoreClient.Dictionary.TryFind "key0" dict
+dict.Add("key0", 42) |> cluster.Run
+dict.ContainsKey "key0" |> cluster.Run
+dict.TryFind "key0" |> cluster.Run
+dict.TryFind "key-not-there" |> cluster.Run
 
 // contested, distributed updates
 let key = "contestedKey"
 let contestJob = 
     [|1 .. 100|]
     |> CloudFlow.OfArray
-    |> CloudFlow.iterLocal(fun i -> CloudDictionary.AddOrUpdate key (function None -> i | Some v -> i + v) dict |> Local.Ignore)
+    |> CloudFlow.iterLocal(fun i -> dict.AddOrUpdate(key, function None -> i | Some v -> i + v) |> Local.Ignore)
     |> cluster.CreateProcess
 
 contestJob.ShowInfo()
 
 // verify result is correct
-cluster.StoreClient.Dictionary.TryFind key dict
+dict.TryFind key |> cluster.Run
+

--- a/azure/HandsOnTutorial/7-using-cloud-data-files.fsx
+++ b/azure/HandsOnTutorial/7-using-cloud-data-files.fsx
@@ -63,7 +63,7 @@ let freshDirectory = cluster.StoreClient.Directory.Create(directory)
 // Upload data to a cloud file (held in blob storage) where we give the cloud file a name.
 let namedCloudFile = 
     cloud { 
-        let! fileName = CloudPath.Combine(freshDirectory.Path, "file1")
+        let fileName = freshDirectory.Path + "/file1"
         do! CloudFile.Delete(fileName)
         let! file = CloudFile.WriteAllLines(fileName, linesOfFile)
         return file


### PR DESCRIPTION
I think these changes improve the code.  

(It's ok to use instance members for the operations on the cloud dictionaries, given how much shorter the code is that way)
