### PR TITLE
turn on binding redirects by default

### DIFF
--- a/azure/CustomCloudService/MBraceAzureRole/MBraceAzureRole.csproj
+++ b/azure/CustomCloudService/MBraceAzureRole/MBraceAzureRole.csproj
@@ -510,10 +510,10 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="Microsoft.ServiceBus">
-          <HintPath>..\..\..\packages\WindowsAzure.ServiceBus\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
+          <HintPath>..\..\..\packages\WindowsAzure.ServiceBus\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/azure/CustomCloudService/MBraceAzureRole/app.config
+++ b/azure/CustomCloudService/MBraceAzureRole/app.config
@@ -11,49 +11,73 @@
     </system.diagnostics>
 
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.WindowsAzure.Configuration" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.3.13283" newVersion="2.6.3.13283" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    
+  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.3.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.6.4.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.6.4.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="6.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.6.4.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Configuration" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-2.6.3.13283" newVersion="2.6.3.13283" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.6.4.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.0.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Mono.Cecil.Mdb" publicKeyToken="0738eb9f132ed756" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.6.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Mono.Cecil.Pdb" publicKeyToken="0738eb9f132ed756" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.6.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Mono.Cecil" publicKeyToken="0738eb9f132ed756" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.6.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Mono.Cecil.Rocks" publicKeyToken="0738eb9f132ed756" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.6.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="System.Threading" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.2856.102" />
+  </dependentAssembly>
+</assemblyBinding></runtime>
 <system.serviceModel>
     <extensions>
       <!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->

--- a/azure/HandsOnTutorial/HandsOnTutorial.fsproj
+++ b/azure/HandsOnTutorial/HandsOnTutorial.fsproj
@@ -89,6 +89,7 @@
     <None Include="999-process-create-perf.fsx" />
     <None Include="999-misc-cpu-perf.fsx" />
     <None Include="paket.references" />
+    <Content Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,3 +1,4 @@
+redirects: on
 source https://www.nuget.org/api/v2
 
 nuget MBrace.Azure 0.7.0-alpha
@@ -8,5 +9,6 @@ nuget MathNet.Numerics
 nuget MathNet.Numerics.FSharp
 nuget MathNet.Numerics.MKL.Win-x64
 nuget Streams
-nuget Suave
+nuget Suave 0.32.0
 nuget FSharp.Core < 4
+

--- a/paket.lock
+++ b/paket.lock
@@ -1,3 +1,4 @@
+REDIRECTS: ON
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
@@ -39,7 +40,7 @@ NUGET
     Mono.Cecil (0.9.6.1)
     Newtonsoft.Json (6.0.8)
     Streams (0.3.0)
-    Suave (0.30.0)
+    Suave (0.32.0-owin)
       FSharp.Core (>= 3.1.2.1)
       FsPickler (>= 1.2.5)
     System.Spatial (5.6.4)
@@ -47,9 +48,9 @@ NUGET
     Vagabond (0.7.5)
       FsPickler (>= 1.2.2 < 1.3.0)
       Mono.Cecil (0.9.6.1)
-    WindowsAzure.ServiceBus (2.7.6)
+    WindowsAzure.ServiceBus (3.0.1)
       Microsoft.WindowsAzure.ConfigurationManager
-    WindowsAzure.Storage (5.0.0)
+    WindowsAzure.Storage (5.0.2)
       Microsoft.Azure.KeyVault.Core (>= 1.0.0) - framework: wpv8.0, >= net40
       Microsoft.Data.OData (>= 5.6.4) - framework: winv4.5, wpv8.1, wpv8.0, >= net40
       Microsoft.Data.Services.Client (>= 5.6.4) - framework: >= net40


### PR DESCRIPTION
Paket's generation of binding redirects should be on to make custom cluster deployment more robust

Also updating to Suave 0.32.0 since that seems to induce the fewest version dependencies in a ``paket update``


