### PR TITLE
Cleanup 35

### DIFF
--- a/HandsOnTutorial/2-cloud-parallel.fsx
+++ b/HandsOnTutorial/2-cloud-parallel.fsx
@@ -14,7 +14,7 @@ open MBrace.Flow
 let cluster = Config.GetCluster() 
 
 (**
-# Simple Cloud Parallelism 
+# Introduction to Cloud Combinators
 
 You now perform a very simple parallel distributed job on your MBrace cluster.
 

--- a/HandsOnTutorial/3-cloud-parallel-cpu-intensive.fsx
+++ b/HandsOnTutorial/3-cloud-parallel-cpu-intensive.fsx
@@ -18,7 +18,7 @@ let cluster = Config.GetCluster()
 #load "lib/sieve.fsx"
 
 (**
-# Using MBrace.Azure for CPU-intensive work
+# Introduction to CPU-intensive Cloud Parallelism
 
 In this tutorial you learn how to perform CPU-intensive cloud-parallel workload on your MBrace cluster.
 The work will be computing prime numbers, though you can easily replace this with any code

--- a/HandsOnTutorial/4-cloud-parallel-data-flow.fsx
+++ b/HandsOnTutorial/4-cloud-parallel-data-flow.fsx
@@ -17,7 +17,7 @@ let cluster = Config.GetCluster()
 
 
 (**
-# Using Data Parallel Cloud Flows
+# Introduction to Data Parallel Cloud Flows
 
 You now learn the CloudFlow programming model, for cloud-scheduled
 parallel data flow tasks.  This model is similar to Hadoop and Spark.

--- a/HandsOnTutorial/6-using-cloud-values.fsx
+++ b/HandsOnTutorial/6-using-cloud-values.fsx
@@ -14,7 +14,7 @@ open MBrace.Flow
 let cluster = Config.GetCluster() 
 
 (**
-# Creating and Using Cloud Values and Cloud Sequences
+# Creating and Using Cloud Values 
 
 # Using Cloud Values 
 

--- a/HandsOnTutorial/AzureCluster.fsx
+++ b/HandsOnTutorial/AzureCluster.fsx
@@ -21,8 +21,9 @@ module Config =
     // The service bus connection string is of the form
     //    Endpoint=sb://%s.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=%s
 
-    let myStorageConnectionString = "your storage connection string here"
-    let myServiceBusConnectionString = "your service bus connection string here"
+
+    let myStorageConnectionString = "DefaultEndpointsProtocol=https;AccountName=mbrace10storage;AccountKey=QIgkxF317t36PwbjQF3stydjhpH6069vft1D8Iv6uglyIqTw8tWkfN1I0m778Ve0IBmkl3Emgo9qkrjANcQi2A=="
+    let myServiceBusConnectionString = "Endpoint=sb://mbrace10bus.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=1QqM8VH4oFxpZQlidXIv8kRG/q4Wh8yLfPgURQc+QNQ="
 
     // Alternatively you can specify the connection strings by calling the functions below
     //

--- a/HandsOnTutorial/examples/200-starting-a-web-server-example.fsx
+++ b/HandsOnTutorial/examples/200-starting-a-web-server-example.fsx
@@ -156,7 +156,7 @@ let endPointNames =
     |> cluster.Run
 
 (**
-By default, MBrace.Azure clusters created using Brisk engine on Azure allow us to bind to 
+By default, MBrace.Azure clusters created using the Azure CustomCloudService allow us to bind to 
 
 * HTTP endpoint 'DefaultHttpEndpoint'
 * HTTP endpoint 'MBraceStats'

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A collection of templates, demos and tutorials for [MBrace](http://m-brace.net/)
 The directory [HandsOnTutorial](HandsOnTutorial) contains a set of scripted 
 hands-on tutorials showing how to use an MBrace cluster from F# Interactive.
 
-1. Provision your cluster, see below.
+1. Provision your cluster, see [m-brace.net](http://m-brace.net/#try).
 2. Open and build the solution ``MBrace.StarterKit.sln`` before working with the scripts
    to restore the necessary packages.
 
-### Azure Worker Role Templates & Tutorials.
+### Azure Cluster Templates & Tutorials.
 
 See also [azure/README.md](azure/README.md)
 
-* [Tutorial](azure/brisk-tutorial.md) on provisioning MBrace using Brisk.
-* [Azure Service Template](azure/CustomCloudService/MBrace.Azure.CloudService.sln) for provisioning MBrace clusters using Visual Studio (Azure SDK 2.7 required.)
+* [Azure Cluster (provisioned as a Custom Cloud Service)](azure/CustomCloudService/MBrace.Azure.CloudService.sln) for provisioning MBrace clusters using Visual Studio (Azure SDK 2.7 required.)
+* [Azure Cluster With Python (provisioned as a Custom Cloud Service)](azure/ProvisionWithPython/MBrace.Azure.CloudServiceWithPython.sln) for provisioning MBrace clusters with Python or other customer installation on the workers (Azure SDK 2.7 required.)

--- a/azure/CustomCloudService/MBrace.Azure.CloudService.sln
+++ b/azure/CustomCloudService/MBrace.Azure.CloudService.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
-MinimumVisualStudioVersion = 10.0.40219.1
+MinimumVisualStudioVersion = 12.0.40629.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".project", ".project", "{73AFA19D-DD5C-4352-8208-BB674630EED4}"
 	ProjectSection(SolutionItems) = preProject
 		..\brisk-tutorial.md = ..\brisk-tutorial.md

--- a/azure/CustomCloudService/MBrace.Azure.CloudService/ServiceDefinition.csdef
+++ b/azure/CustomCloudService/MBrace.Azure.CloudService/ServiceDefinition.csdef
@@ -1,13 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ServiceDefinition name="MBraceAzureService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition" schemaVersion="2015-04.2.6">
-  <WorkerRole name="MBrace.Azure.WorkerRole" vmsize="Large">
-    <LocalResources>
-      <LocalStorage name="LocalMBraceCache" cleanOnRoleRecycle="true" sizeInMB="409600" />
-    </LocalResources>
-    <ConfigurationSettings>
-      <Setting name="MBrace.StorageConnectionString" />
-      <Setting name="MBrace.ServiceBusConnectionString" />
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
-    </ConfigurationSettings>
-  </WorkerRole>
+	<WorkerRole name="MBrace.Azure.WorkerRole" vmsize="Large">
+		<LocalResources>
+			<LocalStorage name="LocalMBraceCache" cleanOnRoleRecycle="true" sizeInMB="409600" />
+		</LocalResources>
+		<ConfigurationSettings>
+			<Setting name="MBrace.StorageConnectionString" />
+			<Setting name="MBrace.ServiceBusConnectionString" />
+			<Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
+		</ConfigurationSettings>
+		<Endpoints>
+			<InputEndpoint name="DefaultHttpEndpoint" protocol="http" port="80" />
+			<InputEndpoint name="MBraceStats" protocol="http" port="8083" />
+			<InputEndpoint name="DefaultTcpEndpoint" protocol="tcp" port="10100" />
+			<!-- <InputEndpoint name="DefaultHttpsEndpoint" protocol="https" port="443" certificate="SSL"/> -->
+			<!-- <InputEndpoint name="DefaultNetTcpEndpoint" protocol="tcp" port="808" certificate="SSL"/> -->
+		</Endpoints>
+	</WorkerRole>
 </ServiceDefinition>

--- a/azure/ProvisionWithPython/MBrace.Azure.CloudService/ServiceDefinition.csdef
+++ b/azure/ProvisionWithPython/MBrace.Azure.CloudService/ServiceDefinition.csdef
@@ -1,18 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ServiceDefinition name="MBraceAzureService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition" schemaVersion="2015-04.2.6">
-  <WorkerRole name="MBrace.Azure.WorkerRole" vmsize="Large">
-    <Runtime executionContext ="elevated" />
-    <LocalResources>
-      <LocalStorage name="LocalMBraceCache" cleanOnRoleRecycle="true" sizeInMB="409600" />
-    </LocalResources>
-    <ConfigurationSettings>
-      <Setting name="MBrace.StorageConnectionString" />
-      <Setting name="MBrace.ServiceBusConnectionString" />
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
-    </ConfigurationSettings>
-    <Startup>
-      <Task commandLine="startup.cmd" executionContext="elevated" taskType="simple">
-      </Task>
-    </Startup>
-  </WorkerRole>
+	<WorkerRole name="MBrace.Azure.WorkerRole" vmsize="Large">
+		<Runtime executionContext ="elevated" />
+		<LocalResources>
+			<LocalStorage name="LocalMBraceCache" cleanOnRoleRecycle="true" sizeInMB="409600" />
+		</LocalResources>
+		<ConfigurationSettings>
+			<Setting name="MBrace.StorageConnectionString" />
+			<Setting name="MBrace.ServiceBusConnectionString" />
+			<Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
+		</ConfigurationSettings>
+		<Startup>
+			<Task commandLine="startup.cmd" executionContext="elevated" taskType="simple">
+			</Task>
+		</Startup>
+		<Endpoints>
+			<InputEndpoint name="DefaultHttpEndpoint" protocol="http" port="80" />
+			<InputEndpoint name="MBraceStats" protocol="http" port="8083" />
+			<InputEndpoint name="DefaultTcpEndpoint" protocol="tcp" port="10100" />
+			<!-- <InputEndpoint name="DefaultHttpsEndpoint" protocol="https" port="443" certificate="SSL"/> -->
+			<!-- <InputEndpoint name="DefaultNetTcpEndpoint" protocol="tcp" port="808" certificate="SSL"/> -->
+		</Endpoints>
+	</WorkerRole>
 </ServiceDefinition>

--- a/azure/README.md
+++ b/azure/README.md
@@ -8,18 +8,21 @@ The directory contains template solutions for this.
 You will need the [Azure SDK 2.7](http://azure.microsoft.com/en-us/downloads/).
 
 1. Make a copy of the `CustomCloudService` directory.
-2. Create a service bus and storage account from the Azure web portal.  After creating the service bus, create 
-   a queue and a topic. You can choose any name for the storage account, server bus, the queue and the topic.
-   Note the connection strings for your Azure Service Bus and Azure Storage accounts.
-3. Insert your Service Bus and Azure Storage connection strings in the `ServiceConfiguration.Cloud.cscfg` file.
-4. In the `MBrace.Azure.CloudService/Roles` subfolder, right click on `MBrace.Azure.WorkerRole` and go to properties to 
-   set the desired instance count and [worker size](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-size-specs/). 
-   You can scale the instance count of the cluster separately later using the [Azure management web portal](https://manage.windowsazure.com/).
-5. Build your solution.
-6. Right click and Publish the `MBrace.Azure.CloudService` project.
+
+2. Create an Azure account using the [Azure management portal](https://manage.windowsazure.com/).
+
+3. Using the Azure management portal:
+
+   * Create a storage account. Use any name (e.g. `mbrace10storage`).  Note the name and the primary access key.
+
+   * Create a service bus account. Use any name (e.g. `mbrace10bus`). Note the `RootManageSharedAccessKey` connection string in the connection information.
+
+4. Insert these names and keys into the `ServiceConfiguration.Cloud.cscfg` file.
+
+5. Right click and Publish the `MBrace.Azure.CloudService` project.  During publication, choose a new name for your cloud service. 
 
 
-After your service is published it should appear as an asset in the [Azure management web portal](https://manage.windowsazure.com/).
+After your service is published it should appear as a cloud service in the [Azure management portal](https://manage.windowsazure.com/).
 
 If using the hands-on tutorials, insert the same connection trings in [MBraceCluster.fsx](../HandsOnTutorial/AzureCluster.fsx#L24) and connect 
 to your runtime (see [hello-world.fsx](../HandsOnTutorial/1-hello-world.fsx) for an example).

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,43 +1,41 @@
 # MBrace on Azure
 
-## Provisioning Your Cluster
+## Provisioning Your MBrace Cluster in Azure
 
-An MBrace cluster can be provisioned on Azure using the following methods:
+An MBrace cluster is provisioned on Azure by deploying an Azure Cloud Service with MBrace Worker Roles.
+The directory contains template solutions for this.
 
-### Use Brisk by Elastacloud
+You will need the [Azure SDK 2.7](http://azure.microsoft.com/en-us/downloads/).
 
-Go to http://www.briskengine.com/ and follow the on-screen instructions.
-A detailed tutorial can be found [here](https://github.com/mbraceproject/MBrace.StarterKits/blob/master/azure/brisk-tutorial.md).
-
-### Creating a Custom Azure Cloud Service with MBrace Worker Roles
-
-The directory contains a collection of solutions for provisioning custom MBrace cloud services on Azure.
-
-1. Clone this repo.
-2. You will need the [Azure SDK 2.7](http://azure.microsoft.com/en-us/downloads/) for the WorkerRole projects.
-3. Depending on your Visual Studio/F# installation, select an appropriate solution from the azure folder.
-4. Insert your Service Bus and Azure Storage connection strings in the `ServiceConfiguration.Cloud.cscfg` file.
-5. In the `MBrace.Azure.CloudService/Roles` subfolder, right click on `MBrace.Azure.WorkerRole` and go to properties to 
+1. Make a copy of the `CustomCloudService` directory.
+2. Create a service bus and storage account from the Azure web portal.  After creating the service bus, create 
+   a queue and a topic. You can choose any name for the storage account, server bus, the queue and the topic.
+   Note the connection strings for your Azure Service Bus and Azure Storage accounts.
+3. Insert your Service Bus and Azure Storage connection strings in the `ServiceConfiguration.Cloud.cscfg` file.
+4. In the `MBrace.Azure.CloudService/Roles` subfolder, right click on `MBrace.Azure.WorkerRole` and go to properties to 
    set the desired instance count and [worker size](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-size-specs/). 
-6. Build your solution.
-7. Right click and Publish the MBraceAzureService project.
-8. If using the hands-on tutorials, insert the same connection 
-   strings in [MBraceCluster.fsx](../HandsOnTutorial/AzureCluster.fsx#L24) and connect 
-   to your runtime (see [hello-world.fsx](../HandsOnTutorial/1-hello-world.fsx) for an example).
+   You can scale the instance count of the cluster separately later using the [Azure management web portal](https://manage.windowsazure.com/).
+5. Build your solution.
+6. Right click and Publish the `MBrace.Azure.CloudService` project.
+
+
+After your service is published it should appear as an asset in the [Azure management web portal](https://manage.windowsazure.com/).
+
+If using the hands-on tutorials, insert the same connection trings in [MBraceCluster.fsx](../HandsOnTutorial/AzureCluster.fsx#L24) and connect 
+to your runtime (see [hello-world.fsx](../HandsOnTutorial/1-hello-world.fsx) for an example).
 
 
 ### Creating custom MBrace Worker Roles with Python installed
-Sometimes, you want to customize the MBrace cluster. For example, you have a machine learning algorithm written in Python and you want to use MBrace to launch it. So you  need to have the Python interpreter and all the dependant Python packages pre-installed in the MBrace cluster.
+
+Sometimes, you want to customize the MBrace cluster with extra software installed on all workers. 
+For example, you have a machine learning algorithm written in Python and you want to use MBrace to launch it. So you  need to have the Python interpreter and all the dependant Python packages pre-installed in the MBrace cluster.
 
 This section describes how to create a MBrace cluster with third-party software installation, and use it from the Mbrace client. The task at hand is:
 
 1. Create a Service Bus. 
 2. Create a custom MBrace cluster with Python installed and with the beautifulsoup4 package setup. 
 3. Publish the custom MBrace cluster.
-4. Use Mbrace client to connect to the custom MBrace cluster. 
-
-### Creating a Service Bus
-You can create a service bus from Azure web portal.  After creating the service bus, create a queue and a topic. You can choose any name for the server bus, the queue and the topic
+4. Use MBrace client to connect to the custom MBrace cluster. 
 
 #### Creating a custom MBrace cluster with Python installed
 


### PR DESCRIPTION
Make titles match those used on the website more closely

Remove mentions of Brisk since it only goes to MBrace 0.6.10

Update cloud service definitions to include default HTTP and TCP endpoints
